### PR TITLE
fix(ci): use context.repo.repo in PR comment action

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -53,6 +53,6 @@ jobs:
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
-            repo: context.repo.name,
+            repo: context.repo.repo,
             body: '✅ **Build Successful!**\n\nThe Alfred workflow has been built successfully. You can download the artifact from the [Actions tab](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).'
           })


### PR DESCRIPTION
## Summary
- One-line fix to `.github/workflows/pr-build.yml`: `context.repo.name` → `context.repo.repo`.
- `context.repo` only exposes `owner` and `repo`; `context.repo.name` is `undefined`, producing the malformed API URL `repos/four13co//issues/N/comments` and a 404 on every PR-to-master.
- The build step itself was succeeding — only the auto-comment was failing — but the failed step was marking the whole job red.
- The fix already exists on `beta`; this just gets master in sync.

## Test plan
- [ ] On merge, the next PR opened against master should post the "Build Successful" comment cleanly and the `PR Build Check` job should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)