### PR TITLE
feat(cusa): send chat message to Super Agent (or any channel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,11 @@ cd alfred-clickup-four13
 
 ## 📝 Changelog
 
-### v1.14 (2025-09-26) - Beta
+### v1.15 (2026-04-26) - Beta
+- **🤖 Send to Super Agent (`cusa`)**: New keyword for posting a chat message to a configured ClickUp channel — built for routing instructions to a Super Agent automation, but works for any channel or DM.
+- **⚙️ Super Agent Channel Picker** in `cu:config`: Browse all ClickUp v3 chat channels — including DMs and group DMs — and pick the target. DMs auto-resolve to the other participant's name (e.g. "DM: Harper Dela Cruz") instead of an opaque ID.
+- **🔔 Confirmation Notifications**: macOS notification on send so you know the message landed.
+- **🔐 Validation**: New `channel` ID validator for v3 chat channel ID format.
 - **📅 Enhanced Due Date Autocomplete**: for much faster due date options
 - **📅 Added Month Relative Dates**: e.g., `@n1` for 1 month etc.
 - **📅 Added Date related Icons**: for better visual cues

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ import sys
 from workflow import Workflow, ICON_WARNING, web, PasswordNotFound
 from validation import validate_clickup_id, validate_api_key
 
-confNames = {'confApi': 'apiKey', 'confDue': 'dueDate', 'confList': 'list', 'confSpace': 'space', 'confTeam': 'workspace', 'confProject': 'folder', 'confNotification': 'notification', 'confDefaultTag': 'defaultTag', 'confUser': 'userId', 'confSearchScope': 'searchScope', 'confSearchEntities': 'searchEntities'}
+confNames = {'confApi': 'apiKey', 'confDue': 'dueDate', 'confList': 'list', 'confSpace': 'space', 'confTeam': 'workspace', 'confProject': 'folder', 'confNotification': 'notification', 'confDefaultTag': 'defaultTag', 'confUser': 'userId', 'confSearchScope': 'searchScope', 'confSearchEntities': 'searchEntities', 'confSuperAgentChannel': 'superAgentChannel'}
 
 
 def maskApiKey(apiKey):
@@ -96,6 +96,10 @@ def configuration():
 			enabled_types.append('Spaces')
 		entitiesDisplay = ', '.join(enabled_types) if enabled_types else 'Tasks'
 		wf3.add_item(title = 'Configure Search Types' + (' (' + entitiesDisplay + ')' if entitiesDisplay else ''), subtitle = 'Toggle which entity types to search', valid = False, autocomplete = confNames['confSearchEntities'] + ' ')
+		superAgentChannelValue = getConfigValue(confNames['confSuperAgentChannel'])
+		superAgentChannelMeta = wf.settings.get('superAgentChannelMeta') or {}
+		superAgentDisplay = superAgentChannelMeta.get('name') or superAgentChannelValue or ''
+		wf3.add_item(title = 'Set Super Agent channel' + (' (' + superAgentDisplay + ')' if superAgentDisplay else ''), subtitle = 'Chat channel that cusa <message> posts to.', valid = False, autocomplete = confNames['confSuperAgentChannel'] + ' ')
 		wf3.add_item(title = 'Validate Configuration', subtitle = 'Check if provided configuration parameters are valid.', valid = False, autocomplete = 'validate', icon = './settings.png')
 		clearCache = wf3.add_item(title = 'Clear Cache', subtitle = 'Clear list of available labels and lists to be retrieved again.', valid = True, arg = 'cu:config cache', icon = './settings.png')
 		clearCache.setvar('isSubmitted', 'true') # No secondary screen necessary
@@ -605,6 +609,150 @@ def configuration():
 					arg = 'cu:config ' + query
 				)
 				confirmItem.setvar('isSubmitted', 'true')
+	elif query.startswith(confNames['confSuperAgentChannel'] + ' '):
+		# Fetch and display chat channels for the configured workspace
+		search_query = query.replace(confNames['confSuperAgentChannel'] + ' ', '').strip()
+		workspace_id = getConfigValue(confNames['confTeam'])
+		if not workspace_id:
+			wf3.add_item(
+				title='Workspace not set',
+				subtitle='Please set your workspace first',
+				valid=False,
+				icon='error.png'
+			)
+		else:
+			try:
+				apiKey = wf.get_password('clickUpAPI')
+				cache_key = f'chat_channels_{workspace_id}'
+				channels = wf.cached_data(cache_key, None, max_age=300)
+				validated_workspace_id = None
+				if not channels:
+					try:
+						validated_workspace_id = validate_clickup_id(workspace_id, 'workspace')
+						url = f'https://api.clickup.com/api/v3/workspaces/{validated_workspace_id}/chat/channels'
+						headers = {
+							'Authorization': validate_api_key(apiKey),
+							'Content-Type': 'application/json'
+						}
+						response = web.get(url, headers=headers, timeout=30)
+						response.raise_for_status()
+						data = response.json()
+						channels = data.get('channels', data.get('data', []))
+					except:
+						wf3.add_item(
+							title='Error fetching chat channels',
+							subtitle='Check workspace ID and internet connection',
+							valid=False,
+							icon='error.png'
+						)
+						wf3.send_feedback()
+						return
+
+				# Enrich any unnamed channels (DMs/group DMs) with member info.
+				# Runs whether channels came from cache or fresh fetch — handles older
+				# unenriched cache entries from earlier workflow versions.
+				needs_enrich = any(
+					not (c.get('name') or '').strip() and not c.get('members')
+					for c in channels
+				)
+				if needs_enrich:
+					try:
+						if validated_workspace_id is None:
+							validated_workspace_id = validate_clickup_id(workspace_id, 'workspace')
+						headers = {
+							'Authorization': validate_api_key(apiKey),
+							'Content-Type': 'application/json'
+						}
+						# Identify the current user so we can exclude them from DM labels
+						self_user_id = getConfigValue(confNames['confUser'])
+						for channel in channels:
+							if (channel.get('name') or '').strip():
+								continue
+							if channel.get('members'):
+								continue
+							ch_id = channel.get('id')
+							if not ch_id:
+								continue
+							try:
+								members_url = f'https://api.clickup.com/api/v3/workspaces/{validated_workspace_id}/chat/channels/{ch_id}/members'
+								members_response = web.get(members_url, headers=headers, timeout=15)
+								members_response.raise_for_status()
+								members_payload = members_response.json()
+								raw_members = members_payload.get('data', members_payload.get('members', members_payload if isinstance(members_payload, list) else []))
+								# Drop the current user so a 1:1 DM displays as the *other* person.
+								if self_user_id:
+									raw_members = [m for m in raw_members if str(m.get('id')) != str(self_user_id)]
+								channel['members'] = raw_members
+							except Exception:
+								pass
+						wf.cache_data(cache_key, channels)
+					except ValueError:
+						pass
+
+				# Build a friendly label per channel — DMs in ClickUp v3 have no `name`
+				def _channel_label(channel):
+					name = (channel.get('name') or '').strip()
+					if name:
+						return name, 'channel'
+					# Try common DM/participant shapes the v3 API may return
+					members = channel.get('members') or channel.get('users') or channel.get('participants') or []
+					member_names = []
+					for m in members:
+						user = m.get('user') if isinstance(m, dict) else None
+						if isinstance(user, dict):
+							member_names.append(user.get('username') or user.get('email') or '')
+						elif isinstance(m, dict):
+							member_names.append(m.get('username') or m.get('email') or m.get('name') or '')
+					member_names = [n for n in member_names if n]
+					ch_type = (channel.get('type') or '').lower()
+					if member_names:
+						joined = ', '.join(member_names[:3])
+						if len(member_names) > 3:
+							joined += f' +{len(member_names) - 3}'
+						label_type = 'dm' if ch_type in ('dm', 'direct_message', 'direct') or len(member_names) <= 2 else 'group'
+						return f'DM: {joined}' if label_type == 'dm' else f'Group: {joined}', label_type
+					# Fall back: short id with explicit type
+					short_id = channel.get('id', '')[:14]
+					return f'{ch_type or "channel"} {short_id}', ch_type or 'channel'
+
+				# Filter on the friendly label so DM searches work too
+				if search_query:
+					q = search_query.lower()
+					filtered = [c for c in channels if q in _channel_label(c)[0].lower() or q in (c.get('id') or '').lower()]
+				else:
+					filtered = channels
+				if filtered:
+					for channel in filtered:
+						channel_id = channel.get('id') or ''
+						channel_label, channel_type = _channel_label(channel)
+						type_badge = '👥' if channel_type in ('group',) else ('✉️' if channel_type in ('dm', 'direct_message', 'direct') else '💬')
+						channelItem = wf3.add_item(
+							title=f'{type_badge} {channel_label}',
+							subtitle=f"{channel_type or 'channel'} · ID {channel_id} — Use as Super Agent target",
+							arg=f"cu:config {confNames['confSuperAgentChannel']} {channel_id}|{channel_label}",
+							valid=True
+						)
+						channelItem.setvar('isSubmitted', 'true')
+				else:
+					if search_query:
+						wf3.add_item(
+							title='No channels found',
+							subtitle='Type to search by channel name',
+							valid=False
+						)
+					else:
+						wf3.add_item(
+							title='No chat channels available',
+							subtitle='Create one in ClickUp first',
+							valid=False
+						)
+			except PasswordNotFound:
+				wf3.add_item(
+					title='API key not set',
+					subtitle='Please set your API key first',
+					valid=False,
+					icon='error.png'
+				)
 	elif query.startswith('validate'): # No suffix ' ' needed, as user is not expected to provide any input.
 		wf3.add_item(title = 'Checking API Key: ' + ('✓' if checkClickUpId('list', 'confList') else '✗'), valid = True, arg = 'cu:config ')
 		wf3.add_item(title = 'Checking List Id: ' + ('✓' if checkClickUpId('list', 'confList') else '✗'), valid = True, arg = 'cu:config ')

--- a/configStore.py
+++ b/configStore.py
@@ -64,6 +64,30 @@ def updateConfiguration():
 			log.debug(wf.cached_data('availableLists', None, max_age = 600))
 		notify('Cleared Cache', 'Lists and labels will be retrieved from ClickUp again.')
 		#Notify cache cleared
+	elif configName == confNames['confSuperAgentChannel']:
+		# Accept either "id|name" (from picker) or just "id" (from manual entry)
+		if '|' in userInput:
+			channel_id, channel_name = userInput.split('|', 1)
+		else:
+			channel_id, channel_name = userInput, ''
+		channel_id = channel_id.strip()
+		channel_name = channel_name.strip()
+		if channel_id == '':
+			if confNames['confSuperAgentChannel'] in wf.settings:
+				wf.settings.pop(confNames['confSuperAgentChannel'])
+			if 'superAgentChannelMeta' in wf.settings:
+				wf.settings.pop('superAgentChannelMeta')
+			wf.settings.save()
+			notify('Super Agent Channel Cleared', 'cusa is now disabled until reconfigured.')
+		else:
+			wf.settings[confNames['confSuperAgentChannel']] = channel_id
+			if channel_name:
+				wf.settings['superAgentChannelMeta'] = {'name': channel_name}
+			elif 'superAgentChannelMeta' in wf.settings:
+				wf.settings.pop('superAgentChannelMeta')
+			wf.settings.save()
+			notify('Super Agent Channel Set', f'cusa <message> will post to {channel_name or channel_id}.')
+		print("")
 	elif configName == confNames['confSearchEntities'] and userInput.startswith('toggle:'):
 		# Handle toggle command for search entities
 		entity = userInput.replace('toggle:', '')

--- a/info.plist
+++ b/info.plist
@@ -730,6 +730,21 @@
 				<false/>
 			</dict>
 		</array>
+		<key>C5A4F1E2-1A1A-4A1A-9A1A-AAAA00000001</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>C5A4F1E2-2B2B-4B2B-9B2B-BBBB00000002</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>C5A4F1E2-2B2B-4B2B-9B2B-BBBB00000002</key>
+		<array/>
 		<key>E09B9161-F260-4D26-9561-D857E6C992DD</key>
 		<array>
 			<dict>
@@ -2612,6 +2627,78 @@ export adj_bonus=15
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>1</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>keyword</key>
+				<string>cusa</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string></string>
+				<key>script</key>
+				<string>/usr/bin/python3 -O sendAgentMessage.py --filter "$1"</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string>Send a message to the Super Agent...</string>
+				<key>title</key>
+				<string>Send to Super Agent</string>
+				<key>type</key>
+				<integer>0</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>C5A4F1E2-1A1A-4A1A-9A1A-AAAA00000001</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>/usr/bin/python3 -O sendAgentMessage.py --send "$1"</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>C5A4F1E2-2B2B-4B2B-9B2B-BBBB00000002</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
 	</array>
 	<key>readme</key>
 	<string>🚀 Streamline your ClickUp workflow directly from Alfred!
@@ -3147,6 +3234,28 @@ Uses fuzzy search instead of Alfred filtering.</string>
 			<real>230</real>
 			<key>ypos</key>
 			<real>50</real>
+		</dict>
+		<key>C5A4F1E2-1A1A-4A1A-9A1A-AAAA00000001</key>
+		<dict>
+			<key>colorindex</key>
+			<integer>4</integer>
+			<key>note</key>
+			<string>cusa &lt;message&gt; — preview before sending to Super Agent.</string>
+			<key>xpos</key>
+			<real>60</real>
+			<key>ypos</key>
+			<real>1500</real>
+		</dict>
+		<key>C5A4F1E2-2B2B-4B2B-9B2B-BBBB00000002</key>
+		<dict>
+			<key>colorindex</key>
+			<integer>4</integer>
+			<key>note</key>
+			<string>POSTs message to ClickUp v3 chat channel.</string>
+			<key>xpos</key>
+			<real>360</real>
+			<key>ypos</key>
+			<real>1500</real>
 		</dict>
 		<key>D45DBAB6-BA33-45FF-BC9F-922CD6C7188A</key>
 		<dict>

--- a/sendAgentMessage.py
+++ b/sendAgentMessage.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# Sends a chat message to the configured Super Agent ClickUp chat channel.
+# Two modes:
+#   sendAgentMessage.py --filter "<typed text>"  -> Alfred Script Filter preview
+#   sendAgentMessage.py --send   "<typed text>"  -> POSTs to ClickUp v3 chat
+import sys
+import json
+from workflow import Workflow, web, PasswordNotFound
+from workflow.notify import notify
+from config import confNames, getConfigValue
+from validation import validate_clickup_id, validate_api_key
+
+
+def main(wf):
+	args = list(wf.args)
+	mode = 'filter'
+	if args and args[0] in ('--filter', '--send'):
+		mode = args.pop(0).replace('--', '')
+	message = args[0] if args else ''
+
+	if mode == 'filter':
+		showFilter(wf, message)
+	else:
+		sendMessage(wf, message)
+
+
+def showFilter(wf, message):
+	channel_id = getConfigValue(confNames['confSuperAgentChannel'])
+	channel_meta = wf.settings.get('superAgentChannelMeta') or {}
+	channel_name = channel_meta.get('name') or channel_id or ''
+
+	if not channel_id:
+		wf.add_item(
+			title='Super Agent channel not configured',
+			subtitle='Run cu:config and choose "Set Super Agent channel" first.',
+			valid=False,
+			icon='error.png'
+		)
+		wf.send_feedback()
+		return
+
+	target = channel_name or channel_id
+	if not message.strip():
+		wf.add_item(
+			title=f'Send to {target}',
+			subtitle='Type a message and press Enter.',
+			valid=False,
+			icon='icon.png'
+		)
+	else:
+		preview = (message[:80] + '…') if len(message) > 80 else message
+		wf.add_item(
+			title=f'Send to {target}',
+			subtitle=preview,
+			valid=True,
+			arg=message,
+			icon='icon.png'
+		)
+	wf.send_feedback()
+
+
+def sendMessage(wf, message):
+	if not message or not message.strip():
+		notify('Super Agent', '', 'Empty message — nothing sent.')
+		return
+
+	channel_id = getConfigValue(confNames['confSuperAgentChannel'])
+	workspace_id = getConfigValue(confNames['confTeam'])
+	if not channel_id or not workspace_id:
+		notify('Super Agent', 'Not configured', 'Set workspace and Super Agent channel in cu:config.')
+		return
+
+	try:
+		validated_workspace_id = validate_clickup_id(workspace_id, 'workspace')
+		validated_channel_id = validate_clickup_id(channel_id, 'channel')
+	except ValueError as e:
+		notify('Super Agent', 'Invalid IDs', str(e))
+		return
+
+	try:
+		api_key = validate_api_key(getConfigValue(confNames['confApi']))
+	except (ValueError, PasswordNotFound) as e:
+		notify('Super Agent', 'Invalid API key', str(e))
+		return
+
+	url = f'https://api.clickup.com/api/v3/workspaces/{validated_workspace_id}/chat/channels/{validated_channel_id}/messages'
+	headers = {
+		'Authorization': api_key,
+		'Content-Type': 'application/json'
+	}
+	body = {
+		'type': 'message',
+		'content_format': 'text/md',
+		'content': message
+	}
+
+	try:
+		request = web.post(url, data=json.dumps(body), headers=headers, timeout=30)
+		request.raise_for_status()
+	except Exception as e:
+		log.debug(f'Chat send failed: {e}')
+		notify('Super Agent — Send Failed', '', 'Check Alfred debug log for details.')
+		return
+
+	channel_meta = wf.settings.get('superAgentChannelMeta') or {}
+	target = channel_meta.get('name') or channel_id
+	preview = (message[:120] + '…') if len(message) > 120 else message
+	notify('Sent to Super Agent', target, preview)
+
+
+if __name__ == '__main__':
+	wf = Workflow()
+	log = wf.logger
+	sys.exit(wf.run(main))

--- a/validation.py
+++ b/validation.py
@@ -41,6 +41,7 @@ def validate_clickup_id(id_value, id_type='generic'):
         'list': r'^[a-zA-Z0-9]+$',        # Alphanumeric, variable length
         'folder': r'^[a-zA-Z0-9]+$',      # Alphanumeric, variable length
         'custom_task': r'^[A-Z0-9_]+$',   # Uppercase with underscores
+        'channel': r'^[a-zA-Z0-9\-]+$',   # Chat channel IDs (v3 API): alphanumeric + hyphens
         'generic': r'^[a-zA-Z0-9_]+$'     # Most permissive pattern
     }
     


### PR DESCRIPTION
## Summary
Adds a new Alfred keyword **`cusa <message>`** that posts the message to a configured ClickUp v3 chat channel. Built for routing instructions to a Super Agent automation, but works equally well for any channel or DM.

## What's wired
- **`cusa <message>`** — new script filter (preview-before-send) → script action posting to `POST /v3/workspaces/{ws}/chat/channels/{ch}/messages`.
- **`cu:config` → "Set Super Agent channel"** — new chat-channel picker. DMs (which have no `name` in v3) get enriched via the `/chat/channels/{id}/members` endpoint and labelled by the *other* participant — e.g. `✉️ DM: Harper Dela Cruz - EA / CoS Super Agent` instead of `dm h62ja-438737`.
- **macOS notification** on send so you know it landed.
- **New `channel` validator** in `validation.py` for v3 chat-channel IDs (alphanumeric + hyphens).

## Release notes (added to README)
> ### v1.15 (2026-04-26) - Beta
> - 🤖 Send to Super Agent (`cusa`): new keyword for posting a chat message to a configured ClickUp channel.
> - ⚙️ Super Agent Channel Picker in `cu:config`: browse all v3 chat channels — including DMs and group DMs — and pick the target.
> - 🔔 Confirmation Notifications: macOS notification on send.
> - 🔐 Validation: new `channel` ID validator for v3 chat channel format.

## How to try it
1. Build the workflow on this branch (or wait for the beta release artifact).
2. `cu:config` → "Set Super Agent channel" → pick the DM/channel you want.
3. `cusa hello, please summarize today's open audits` → press Enter.

## Architecture notes
- New confName `confSuperAgentChannel` (workspace-settings) plus a `superAgentChannelMeta` sidecar that stores the human-readable channel label so the config menu and the post-send notification show "DM: Harper Dela Cruz" instead of an opaque ID.
- Picker items set `isSubmitted=true` so after save the workflow returns to the main `cu:config` menu (matches the existing API-key / workspace-picker patterns).
- Member enrichment is lazy: only fires for unnamed channels and only when the cached payload is missing member info, so existing 5-minute cache entries get upgraded transparently.

## Test plan
- [ ] Configure the Super Agent channel and confirm the picker shows DMs by participant name.
- [ ] Send a message via `cusa hello world` — confirm it appears in ClickUp chat and a macOS notification fires.
- [ ] Open `cu:config` and confirm "Set Super Agent channel" shows the saved label.
- [ ] Try `cusa <message>` *before* configuring the channel and confirm the picker shows a "not configured" item rather than crashing.

## Limitations / follow-ups
- Send is fire-and-forget; no in-app preview after send.
- No `cup #channel msg…` general-purpose poster yet — that's the planned follow-up once the `cusa` shape is validated.
- No assignee selection on `cu` task creation (separate work item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)