### PR TITLE
fix: keep Configure Search Types toggles in submenu after click

### DIFF
--- a/config.py
+++ b/config.py
@@ -534,7 +534,7 @@ def configuration():
 				arg = 'cu:config ' + confNames['confSearchEntities'] + ' toggle:docs',
 				icon = 'note.png'
 			)
-			docsItem.setvar('isSubmitted', 'true')
+			docsItem.setvar('isSubmitted', 'false')
 			
 			# Chat Channels
 			chats_enabled = 'chats' in current_entities
@@ -545,7 +545,7 @@ def configuration():
 				arg = 'cu:config ' + confNames['confSearchEntities'] + ' toggle:chats',
 				icon = 'label.png'
 			)
-			chatsItem.setvar('isSubmitted', 'true')
+			chatsItem.setvar('isSubmitted', 'false')
 			
 			# Lists
 			lists_enabled = 'lists' in current_entities
@@ -556,7 +556,7 @@ def configuration():
 				arg = 'cu:config ' + confNames['confSearchEntities'] + ' toggle:lists',
 				icon = 'label.png'
 			)
-			listsItem.setvar('isSubmitted', 'true')
+			listsItem.setvar('isSubmitted', 'false')
 			
 			# Folders
 			folders_enabled = 'folders' in current_entities
@@ -567,7 +567,7 @@ def configuration():
 				arg = 'cu:config ' + confNames['confSearchEntities'] + ' toggle:folders',
 				icon = 'settings.png'
 			)
-			foldersItem.setvar('isSubmitted', 'true')
+			foldersItem.setvar('isSubmitted', 'false')
 			
 			# Spaces
 			spaces_enabled = 'spaces' in current_entities
@@ -578,7 +578,7 @@ def configuration():
 				arg = 'cu:config ' + confNames['confSearchEntities'] + ' toggle:spaces',
 				icon = 'settings.png'
 			)
-			spacesItem.setvar('isSubmitted', 'true')
+			spacesItem.setvar('isSubmitted', 'false')
 			
 		elif userInput.startswith('toggle:'):
 			# This case is now handled directly by configStore.py


### PR DESCRIPTION
## Summary
After toggling a Configure Search Types entity (Documents, Lists, Folders, etc.), the Script Filter was bouncing back to the main `cu:config` menu instead of staying on the submenu, so you couldn't toggle multiple types in one pass.

The previous fix (#?, commit 97a5d17 already on beta) addressed the saving + 'jumps to main' issue. This follow-up keeps you in the Search Types submenu by setting `isSubmitted=false` on the toggle items and scheduling a 0.2s rerun so the submenu re-renders with the new state.

Original commit on the long-running `fix-configure-search-types-toggle` branch — cherry-picked clean onto beta.

## Test plan
- [ ] `cu:config` → "Configure Search Types" → toggle Documents → confirm the menu re-renders with the new ✓/○ state and stays on the submenu (not the root config).
- [ ] Toggle two more types in succession without re-typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)